### PR TITLE
Enable building the debug extension

### DIFF
--- a/in.p1x.TanksOfFreedom.json
+++ b/in.p1x.TanksOfFreedom.json
@@ -12,9 +12,6 @@
      "--share=network",
      "--device=all"
   ],
-  "build-options" : {
-    "no-debuginfo" : true
-  },
   "modules": [
     {
       "name": "scons",


### PR DESCRIPTION
TanksOfFreedom sometimes crashes. I wanted to debug it, but discovered that there is no in.p1x.TanksOfFreedom.Debug

Sample backtrace without debug symbols:
```
handle_crash: Program crashed with signal 11
Dumping the backtrace. Please include this when reporting the bug on https://github.com/godotengine/godot/issues
[1] /usr/lib/x86_64-linux-gnu/libc.so.6(+0x39880) [0x747a9331d880] ()
[2] /app/bin/godot-bin() [0x101e0d8] ()
[3] /app/bin/godot-bin() [0x11128b5] ()
[4] /app/bin/godot-bin() [0x4809d4] ()
[5] /app/bin/godot-bin() [0x4c5998] ()
[6] /app/bin/godot-bin() [0x1020a82] ()
[7] /app/bin/godot-bin() [0x10bcdc2] ()
[8] /app/bin/godot-bin() [0x48180e] ()
[9] /app/bin/godot-bin() [0x4c5998] ()
[10] /app/bin/godot-bin() [0x1020a82] ()
[11] /app/bin/godot-bin() [0x10bcdc2] ()
[12] /app/bin/godot-bin() [0x48180e] ()
[13] /app/bin/godot-bin() [0x4c5998] ()
[14] /app/bin/godot-bin() [0x1020a82] ()
[15] /app/bin/godot-bin() [0x10bcdc2] ()
[16] /app/bin/godot-bin() [0x4805bc] ()
[17] /app/bin/godot-bin() [0x4c5998] ()
[18] /app/bin/godot-bin() [0x1020a82] ()
[19] /app/bin/godot-bin() [0x10bcdc2] ()
[20] /app/bin/godot-bin() [0x4805bc] ()
[21] /app/bin/godot-bin() [0x4c5998] ()
[22] /app/bin/godot-bin() [0x1020a82] ()
[23] /app/bin/godot-bin() [0x10bcdc2] ()
[24] /app/bin/godot-bin() [0x4805bc] ()
[25] /app/bin/godot-bin() [0x4c5998] ()
[26] /app/bin/godot-bin() [0x1020a82] ()
[27] /app/bin/godot-bin() [0x10bcdc2] ()
[28] /app/bin/godot-bin() [0x4805bc] ()
[29] /app/bin/godot-bin() [0x4c5998] ()
[30] /app/bin/godot-bin() [0x1020a82] ()
[31] /app/bin/godot-bin() [0x101f0a0] ()
[32] /app/bin/godot-bin() [0x10337f9] ()
[33] /app/bin/godot-bin() [0x1020b66] ()
[34] /app/bin/godot-bin() [0x10bcdc2] ()
[35] /app/bin/godot-bin() [0x48180e] ()
[36] /app/bin/godot-bin() [0x4c5998] ()
[37] /app/bin/godot-bin() [0x1020a82] ()
[38] /app/bin/godot-bin() [0x1022d80] ()
[39] /app/bin/godot-bin() [0x10210e3] ()
[40] /app/bin/godot-bin() [0x6fd2f1] ()
[41] /app/bin/godot-bin() [0x6ffba4] ()
[42] /app/bin/godot-bin() [0x101db4e] ()
[43] /app/bin/godot-bin() [0x6e9ab9] ()
[44] /app/bin/godot-bin() [0x6e9e20] ()
[45] /app/bin/godot-bin() [0x430be7] ()
[46] /app/bin/godot-bin() [0x412dce] ()
[47] /app/bin/godot-bin(main+0x6d) [0x40b17d] ()
[48] /usr/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf2) [0x747a93308062] ()
[49] /app/bin/godot-bin() [0x40b04e] ()
-- END OF BACKTRACE --
```