### PR TITLE
Update version of Godot Engine and game source

### DIFF
--- a/in.p1x.TanksOfFreedom.appdata.xml
+++ b/in.p1x.TanksOfFreedom.appdata.xml
@@ -36,6 +36,7 @@
     <content_attribute id="social-chat">intense</content_attribute>
   </content_rating>
   <releases>
+    <release version="0.7.1-beta" date="2022-12-22"/>
     <release version="0.7.0-beta" date="2018-05-18"/>
     <release version="0.6.3-beta" date="2017-03-13"/>
     <release version="0.6.2-beta" date="2017-01-04"/>

--- a/in.p1x.TanksOfFreedom.json
+++ b/in.p1x.TanksOfFreedom.json
@@ -33,8 +33,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/godotengine/godot/archive/2.1.5-stable.tar.gz",
-          "sha256": "74179c08bcc20cc89b4ac2785a31f201d81eb4aa875c80ffcb82d9fb80e8e187"
+          "url": "https://github.com/godotengine/godot/archive/2.1.6-stable.tar.gz",
+          "sha256": "5bfc57f2ee24dccfdcefe491a3be1a07b39299f2fcfa03202b8b4c6c2dd5122b"
         }
       ],
       "build-commands": [
@@ -69,8 +69,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/w84death/Tanks-of-Freedom/archive/0.7.0-beta.tar.gz",
-          "sha256": "6ca6a633c82390a3c9dac8ba4481c4f5439dd1b25e732db5552586e9cbf0a74c"
+          "url": "https://github.com/w84death/Tanks-of-Freedom/archive/0.7.1-beta.tar.gz",
+          "sha256": "5af5471f0c2a85f4bad91dff395d7575c4ef6a6707e9ede3882661216d7497db"
         },
         {
           "type": "file",

--- a/in.p1x.TanksOfFreedom.json
+++ b/in.p1x.TanksOfFreedom.json
@@ -5,18 +5,20 @@
   "sdk": "org.freedesktop.Sdk",
   "command": "tanksoffreedom",
   "finish-args": [
-     "--socket=x11",
-     "--socket=pulseaudio",
-     "--persist=.godot",
-     "--share=ipc",
-     "--share=network",
-     "--device=all"
+    "--socket=x11",
+    "--socket=pulseaudio",
+    "--persist=.godot",
+    "--share=ipc",
+    "--share=network",
+    "--device=all"
   ],
   "modules": [
     {
       "name": "scons",
       "buildsystem": "simple",
-      "cleanup": [ "*" ],
+      "cleanup": [
+        "*"
+      ],
       "sources": [
         {
           "type": "archive",
@@ -24,7 +26,9 @@
           "sha256": "e2b8b36e25492720a05c0f0a92a219b42d11ce0c51e3397a1e8296dfea1d9b1a"
         }
       ],
-      "build-commands": [ "python setup.py install --prefix=${FLATPAK_DEST} --optimize=1" ]
+      "build-commands": [
+        "python setup.py install --prefix=${FLATPAK_DEST} --optimize=1"
+      ]
     },
     "shared-modules/glu/glu-9.json",
     {
@@ -38,30 +42,8 @@
         }
       ],
       "build-commands": [
-        "scons platform=x11 \\
-          CCFLAGS=-I${C_INCLUDE_PATH} \\
-          prefix=${FLATPAK_DEST} \\
-          unix_global_settings_path=${FLATPAK_DEST} \\
-          verbose=yes \\
-          -j $FLATPAK_BUILDER_N_JOBS \\
-          target=release_debug \\
-          use_llvm=yes \\
-          builtin_freetype=no \\
-          builtin_libmpcdec=yes \\
-          builtin_libogg=no \\
-          builtin_libpng=no \\
-          builtin_libtheora=no \\
-          builtin_libvorbis=no \\
-          builtin_libwebp=no \\
-          builtin_libvpx=no \\
-          builtin_zlib=no \\
-          builtin_opus=yes \\
-          builtin_speex=yes \\
-          builtin_squish=yes \\
-          pulseaudio=yes \\
-          udev=no \\
-          tools=no",
-          "install -D -m755 bin/godot* ${FLATPAK_DEST}/bin/godot-bin"
+        "scons platform=x11 CCFLAGS=-I${C_INCLUDE_PATH} prefix=${FLATPAK_DEST} unix_global_settings_path=${FLATPAK_DEST} verbose=yes -j $FLATPAK_BUILDER_N_JOBS target=release_debug use_llvm=yes builtin_freetype=no builtin_libmpcdec=yes builtin_libogg=no builtin_libpng=no builtin_libtheora=no builtin_libvorbis=no builtin_libwebp=no builtin_libvpx=no builtin_zlib=no builtin_opus=yes builtin_speex=yes builtin_squish=yes pulseaudio=yes udev=no tools=no",
+        "install -D -m755 bin/godot* ${FLATPAK_DEST}/bin/godot-bin"
       ]
     },
     {
@@ -90,9 +72,7 @@
       ],
       "buildsystem": "simple",
       "post-install": [
-        "for size in 16 24 32 48 128 256 512; do 
-        install -Dm644 ${FLATPAK_DEST}/tanksoffreedom/assets/icons/icon${size}.png ${FLATPAK_DEST}/share/icons/hicolor/${size}x${size}/apps/${FLATPAK_ID}.png
-        done"
+        "for size in 16 24 32 48 128 256 512; do install -Dm644 ${FLATPAK_DEST}/tanksoffreedom/assets/icons/icon${size}.png ${FLATPAK_DEST}/share/icons/hicolor/${size}x${size}/apps/${FLATPAK_ID}.png; done"
       ],
       "build-commands": [
         "install -Dm755 tanksoffreedom.sh ${FLATPAK_DEST}/bin/tanksoffreedom",


### PR DESCRIPTION
Bumped versions:
- Godot Engine from 2.1.5 to 2.1.6
- Game source from 0.7.0 to 0.7.1